### PR TITLE
Update GitHub Actions to use self-hosted runners for build jobs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: [self-hosted, windows, x64]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run_and_test.yaml
+++ b/.github/workflows/run_and_test.yaml
@@ -14,7 +14,7 @@ jobs:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: windows-latest
+    runs-on: [self-hosted, windows, x64]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Now the actions are running on the self hosted server, since OpenCL is not supported on GH Actions